### PR TITLE
Explicitly convert shared_ptr to bool for C++11 compatibility

### DIFF
--- a/storm/storm3dv2/storm3d_spotlight.cpp
+++ b/storm/storm3dv2/storm3d_spotlight.cpp
@@ -564,7 +564,7 @@ void Storm3D_Spotlight::setConeTexture(boost::shared_ptr<IStorm3D_Texture> textu
  */
 bool Storm3D_Spotlight::hasConeTexture() const
 {
-    return data->coneTexture;
+    return !!data->coneTexture;
 }
 
 //! Set color multiplier

--- a/storm/storm3dv2/storm3d_terrain_models.cpp
+++ b/storm/storm3dv2/storm3d_terrain_models.cpp
@@ -1773,7 +1773,7 @@ void Storm3D_TerrainModels::buildTree(const VC3 &size)
  */
 bool Storm3D_TerrainModels::hasTree() const
 {
-    return data->tree;
+    return !!data->tree;
 }
 
 //! Raytrace


### PR DESCRIPTION
On current systems with C++11, the engine fails to build as shared_ptr can no longer be implicitly converted to bool. (See: https://stackoverflow.com/questions/7580009/gcc-error-cannot-convert-const-shared-ptr-to-bool-in-return ) 